### PR TITLE
Add truth table in editor and Half Adder and Full Adder

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "gately",

--- a/src/components/nodes/base/gate-renderer.tsx
+++ b/src/components/nodes/base/gate-renderer.tsx
@@ -118,7 +118,15 @@ export function GateRenderer({
 
           {/* Select pin stub */}
           {hasSelectPin && (
-            <line x1={CW / 2} y1={CH + hs} x2={CW / 2} y2={CH - 10} stroke={activeColor} strokeWidth="1.5" opacity="0.5" />
+            <line
+              x1={CW / 2}
+              y1={CH + hs}
+              x2={CW / 2}
+              y2={CH - 10}
+              stroke={activeColor}
+              strokeWidth="1.5"
+              opacity="0.5"
+            />
           )}
 
           {/* Output stub wires */}

--- a/src/components/nodes/base/gate-renderer.tsx
+++ b/src/components/nodes/base/gate-renderer.tsx
@@ -3,11 +3,22 @@
 
 import { Position } from "@xyflow/react";
 import { useState } from "react";
-import { H, hs, W } from "./constants";
+import { H, HANDLE_SIZE, hs, W } from "./constants";
 import { InputHandle, OutputHandle } from "./gate-handle";
 import type { GateRendererProps } from "./types";
 
-export function GateRenderer({ data, isConnectable, geometry, label, inputHandles, outputHandles }: GateRendererProps) {
+export function GateRenderer({
+  id,
+  data,
+  isConnectable,
+  geometry,
+  label,
+  symbol,
+  inputHandles = 2,
+  outputHandles = 1,
+  width: CW = W,
+  height: CH = H,
+}: GateRendererProps & { width?: number; height?: number }) {
   const [hovered, setHovered] = useState(false);
   const activeColor = data.preview
     ? "var(--color-foreground)"
@@ -19,20 +30,21 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
 
   const inputYs: (number | null)[] = Array.from({ length: inputHandles }, (_, i) => {
     if (geometry.inputYOverrides && i < geometry.inputYOverrides.length) return geometry.inputYOverrides[i];
-    if (inputHandles === 1) return H / 2;
-    return H * 0.2 + ((H * 0.6) / (inputHandles - 1)) * i;
+    if (inputHandles === 1) return CH / 2;
+    return CH * 0.2 + ((CH * 0.6) / (inputHandles - 1)) * i;
   });
   const selectPinIndex = inputYs.indexOf(null);
 
   const outputYs = Array.from({ length: outputHandles }, (_, i) => {
+    if (geometry.outputYOverrides && i < geometry.outputYOverrides.length) return geometry.outputYOverrides[i]!;
     if (outputHandles === 1) return geometry.outputY;
-    return H * 0.25 + ((H * 0.5) / (outputHandles - 1)) * i;
+    return CH * 0.25 + ((CH * 0.5) / (outputHandles - 1)) * i;
   });
 
   return (
     <div
       className="relative"
-      style={{ width: W, height: H }}
+      style={{ width: CW, height: CH }}
       onMouseEnter={() => !data.preview && setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -40,7 +52,7 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
       <div
         style={{
           position: "absolute",
-          bottom: H + 8,
+          bottom: CH + 8,
           left: "50%",
           transform: "translateX(-50%)",
           pointerEvents: "none",
@@ -67,7 +79,6 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
         >
           {label}
         </div>
-        {/* arrow */}
         <div
           style={{
             width: 0,
@@ -83,9 +94,9 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
       {/* Gate SVG or default rendering */}
       {geometry.bodyPath ? (
         <svg
-          width={W}
-          height={H}
-          viewBox={`0 0 ${W} ${H}`}
+          width={CW}
+          height={CH}
+          viewBox={`0 0 ${CW} ${CH}`}
           className="absolute top-0 left-0"
           style={{ overflow: "visible" }}
         >
@@ -107,7 +118,7 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
 
           {/* Select pin stub */}
           {hasSelectPin && (
-            <line x1={W / 2} y1={H + hs} x2={W / 2} y2={H - 10} stroke={activeColor} strokeWidth="1.5" opacity="0.5" />
+            <line x1={CW / 2} y1={CH + hs} x2={CW / 2} y2={CH - 10} stroke={activeColor} strokeWidth="1.5" opacity="0.5" />
           )}
 
           {/* Output stub wires */}
@@ -116,7 +127,7 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
               key={`wire-out-${i}`}
               x1={geometry.outputX}
               y1={y}
-              x2={W}
+              x2={CW}
               y2={y}
               stroke={activeColor}
               strokeWidth="1.5"
@@ -138,6 +149,9 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
               strokeWidth="2"
             />
           )}
+
+          {/* Inline SVG label slots — rendered by child via geometry.svgContent */}
+          {geometry.svgContent}
         </svg>
       ) : (
         <div
@@ -176,8 +190,13 @@ export function GateRenderer({ data, isConnectable, geometry, label, inputHandle
           position={Position.Bottom}
           style={{
             bottom: -hs,
-            left: W / 2 - hs,
-            top: undefined,
+            left: CW / 2 - hs,
+            width: HANDLE_SIZE,
+            height: HANDLE_SIZE,
+            background: activeColor,
+            border: `2px solid ${bgColor}`,
+            borderRadius: "50%",
+            transform: "none",
           }}
           isConnectable={isConnectable}
         />

--- a/src/components/nodes/base/types.ts
+++ b/src/components/nodes/base/types.ts
@@ -8,6 +8,8 @@ export interface GateGeometry {
   outputY: number;
   inputPinX: number;
   inputYOverrides?: (number | null)[];
+  outputYOverrides?: (number | null)[];
+  svgContent?: React.ReactNode;
 }
 
 export interface GateRendererProps {

--- a/src/components/nodes/fullAdder.tsx
+++ b/src/components/nodes/fullAdder.tsx
@@ -3,66 +3,145 @@
 import { memo } from "react";
 import { type GateGeometry, GateRenderer, H, type LogicGateProps, W } from "./base/index";
 
-
 const FA_W = W;
-const FA_H = Math.round(H * 1.5); 
-const PAD  = 10;
-const RX   = 5;
+const FA_H = Math.round(H * 1.5);
+const PAD = 10;
+const RX = 5;
 
 function rrPath(x: number, y: number, w: number, h: number, r: number) {
   return [
     `M${x + r} ${y}`,
-    `L${x + w - r} ${y}`,     `Q${x + w} ${y}     ${x + w} ${y + r}`,
-    `L${x + w} ${y + h - r}`, `Q${x + w} ${y + h} ${x + w - r} ${y + h}`,
-    `L${x + r} ${y + h}`,     `Q${x}     ${y + h} ${x}     ${y + h - r}`,
-    `L${x}     ${y + r}`,     `Q${x}     ${y}     ${x + r} ${y}`,
+    `L${x + w - r} ${y}`,
+    `Q${x + w} ${y}     ${x + w} ${y + r}`,
+    `L${x + w} ${y + h - r}`,
+    `Q${x + w} ${y + h} ${x + w - r} ${y + h}`,
+    `L${x + r} ${y + h}`,
+    `Q${x}     ${y + h} ${x}     ${y + h - r}`,
+    `L${x}     ${y + r}`,
+    `Q${x}     ${y}     ${x + r} ${y}`,
     "Z",
   ].join(" ");
 }
 
-const FA_INPUT_YS  = [FA_H * 0.25, FA_H * 0.50, FA_H * 0.75];
+const FA_INPUT_YS = [FA_H * 0.25, FA_H * 0.5, FA_H * 0.75];
 const FA_OUTPUT_YS = [FA_H * 0.37, FA_H * 0.63];
 
 function getFullAdderGeometry(activeColor: string): GateGeometry {
   return {
     bodyPath: rrPath(PAD, 4, FA_W - PAD * 2, FA_H - 8, RX),
-    outputX:   FA_W - PAD,
-    outputY:   FA_H / 2,
+    outputX: FA_W - PAD,
+    outputY: FA_H / 2,
     inputPinX: PAD,
-    inputYOverrides:  FA_INPUT_YS,
+    inputYOverrides: FA_INPUT_YS,
     outputYOverrides: FA_OUTPUT_YS,
     svgContent: (
       <>
         {/* subtle dividers */}
-        <line x1={PAD + 4} y1={FA_H * 0.15} x2={FA_W - PAD - 4} y2={FA_H * 0.15}
-          stroke={activeColor} strokeWidth="0.75" opacity="0.12" />
-        <line x1={PAD + 4} y1={FA_H * 0.85} x2={FA_W - PAD - 4} y2={FA_H * 0.85}
-          stroke={activeColor} strokeWidth="0.75" opacity="0.12" />
+        <line
+          x1={PAD + 4}
+          y1={FA_H * 0.15}
+          x2={FA_W - PAD - 4}
+          y2={FA_H * 0.15}
+          stroke={activeColor}
+          strokeWidth="0.75"
+          opacity="0.12"
+        />
+        <line
+          x1={PAD + 4}
+          y1={FA_H * 0.85}
+          x2={FA_W - PAD - 4}
+          y2={FA_H * 0.85}
+          stroke={activeColor}
+          strokeWidth="0.75"
+          opacity="0.12"
+        />
 
-        <text x={FA_W / 2} y={FA_H * 0.10} textAnchor="middle"
-          fontSize="5.5" fontFamily="monospace" fontWeight="700"
-          letterSpacing="0.12em" fill={activeColor} opacity="0.3">1-BIT</text>
+        <text
+          x={FA_W / 2}
+          y={FA_H * 0.1}
+          textAnchor="middle"
+          fontSize="5.5"
+          fontFamily="monospace"
+          fontWeight="700"
+          letterSpacing="0.12em"
+          fill={activeColor}
+          opacity="0.3"
+        >
+          1-BIT
+        </text>
 
-        <text x={FA_W / 2} y={FA_H * 0.93} textAnchor="middle"
-          fontSize="5.5" fontFamily="monospace" fontWeight="700"
-          letterSpacing="0.12em" fill={activeColor} opacity="0.3">FA</text>
+        <text
+          x={FA_W / 2}
+          y={FA_H * 0.93}
+          textAnchor="middle"
+          fontSize="5.5"
+          fontFamily="monospace"
+          fontWeight="700"
+          letterSpacing="0.12em"
+          fill={activeColor}
+          opacity="0.3"
+        >
+          FA
+        </text>
 
-        <text x={PAD + 4} y={FA_INPUT_YS[0] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          fill={activeColor} opacity="0.55">A</text>
-        <text x={PAD + 4} y={FA_INPUT_YS[1] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          fill={activeColor} opacity="0.55">B</text>
-        <text x={PAD + 4} y={FA_INPUT_YS[2] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          fill={activeColor} opacity="0.55">Cin</text>
+        <text
+          x={PAD + 4}
+          y={FA_INPUT_YS[0] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          A
+        </text>
+        <text
+          x={PAD + 4}
+          y={FA_INPUT_YS[1] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          B
+        </text>
+        <text
+          x={PAD + 4}
+          y={FA_INPUT_YS[2] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          Cin
+        </text>
 
-        <text x={FA_W - PAD - 4} y={FA_OUTPUT_YS[0] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          textAnchor="end" fill={activeColor} opacity="0.55">S</text>
-        <text x={FA_W - PAD - 4} y={FA_OUTPUT_YS[1] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          textAnchor="end" fill={activeColor} opacity="0.55">Co</text>
+        <text
+          x={FA_W - PAD - 4}
+          y={FA_OUTPUT_YS[0] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          textAnchor="end"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          S
+        </text>
+        <text
+          x={FA_W - PAD - 4}
+          y={FA_OUTPUT_YS[1] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          textAnchor="end"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          Co
+        </text>
       </>
     ),
   };
@@ -72,8 +151,8 @@ export const FullAdderNode = memo(({ id, data, isConnectable }: LogicGateProps) 
   const activeColor = data.preview
     ? "var(--color-foreground)"
     : data.state
-    ? "var(--color-success)"
-    : "var(--color-primary)";
+      ? "var(--color-success)"
+      : "var(--color-primary)";
 
   return (
     <GateRenderer

--- a/src/components/nodes/fullAdder.tsx
+++ b/src/components/nodes/fullAdder.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { memo } from "react";
+import { type GateGeometry, GateRenderer, H, type LogicGateProps, W } from "./base/index";
+
+
+const FA_W = W;
+const FA_H = Math.round(H * 1.5); 
+const PAD  = 10;
+const RX   = 5;
+
+function rrPath(x: number, y: number, w: number, h: number, r: number) {
+  return [
+    `M${x + r} ${y}`,
+    `L${x + w - r} ${y}`,     `Q${x + w} ${y}     ${x + w} ${y + r}`,
+    `L${x + w} ${y + h - r}`, `Q${x + w} ${y + h} ${x + w - r} ${y + h}`,
+    `L${x + r} ${y + h}`,     `Q${x}     ${y + h} ${x}     ${y + h - r}`,
+    `L${x}     ${y + r}`,     `Q${x}     ${y}     ${x + r} ${y}`,
+    "Z",
+  ].join(" ");
+}
+
+const FA_INPUT_YS  = [FA_H * 0.25, FA_H * 0.50, FA_H * 0.75];
+const FA_OUTPUT_YS = [FA_H * 0.37, FA_H * 0.63];
+
+function getFullAdderGeometry(activeColor: string): GateGeometry {
+  return {
+    bodyPath: rrPath(PAD, 4, FA_W - PAD * 2, FA_H - 8, RX),
+    outputX:   FA_W - PAD,
+    outputY:   FA_H / 2,
+    inputPinX: PAD,
+    inputYOverrides:  FA_INPUT_YS,
+    outputYOverrides: FA_OUTPUT_YS,
+    svgContent: (
+      <>
+        {/* subtle dividers */}
+        <line x1={PAD + 4} y1={FA_H * 0.15} x2={FA_W - PAD - 4} y2={FA_H * 0.15}
+          stroke={activeColor} strokeWidth="0.75" opacity="0.12" />
+        <line x1={PAD + 4} y1={FA_H * 0.85} x2={FA_W - PAD - 4} y2={FA_H * 0.85}
+          stroke={activeColor} strokeWidth="0.75" opacity="0.12" />
+
+        <text x={FA_W / 2} y={FA_H * 0.10} textAnchor="middle"
+          fontSize="5.5" fontFamily="monospace" fontWeight="700"
+          letterSpacing="0.12em" fill={activeColor} opacity="0.3">1-BIT</text>
+
+        <text x={FA_W / 2} y={FA_H * 0.93} textAnchor="middle"
+          fontSize="5.5" fontFamily="monospace" fontWeight="700"
+          letterSpacing="0.12em" fill={activeColor} opacity="0.3">FA</text>
+
+        <text x={PAD + 4} y={FA_INPUT_YS[0] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          fill={activeColor} opacity="0.55">A</text>
+        <text x={PAD + 4} y={FA_INPUT_YS[1] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          fill={activeColor} opacity="0.55">B</text>
+        <text x={PAD + 4} y={FA_INPUT_YS[2] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          fill={activeColor} opacity="0.55">Cin</text>
+
+        <text x={FA_W - PAD - 4} y={FA_OUTPUT_YS[0] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          textAnchor="end" fill={activeColor} opacity="0.55">S</text>
+        <text x={FA_W - PAD - 4} y={FA_OUTPUT_YS[1] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          textAnchor="end" fill={activeColor} opacity="0.55">Co</text>
+      </>
+    ),
+  };
+}
+
+export const FullAdderNode = memo(({ id, data, isConnectable }: LogicGateProps) => {
+  const activeColor = data.preview
+    ? "var(--color-foreground)"
+    : data.state
+    ? "var(--color-success)"
+    : "var(--color-primary)";
+
+  return (
+    <GateRenderer
+      id={id}
+      data={data}
+      isConnectable={isConnectable}
+      geometry={getFullAdderGeometry(activeColor)}
+      label="FULL ADDER"
+      symbol="FA"
+      inputHandles={3}
+      outputHandles={2}
+      width={FA_W}
+      height={FA_H}
+    />
+  );
+});
+
+FullAdderNode.displayName = "FullAdderNode";

--- a/src/components/nodes/halfAdder.tsx
+++ b/src/components/nodes/halfAdder.tsx
@@ -5,54 +5,112 @@ import { type GateGeometry, GateRenderer, H, type LogicGateProps, W } from "./ba
 
 const HA_W = W;
 const HA_H = H;
-const PAD  = 10;
-const RX   = 5;
+const PAD = 10;
+const RX = 5;
 
 function rrPath(x: number, y: number, w: number, h: number, r: number) {
   return [
     `M${x + r} ${y}`,
-    `L${x + w - r} ${y}`,     `Q${x + w} ${y}     ${x + w} ${y + r}`,
-    `L${x + w} ${y + h - r}`, `Q${x + w} ${y + h} ${x + w - r} ${y + h}`,
-    `L${x + r} ${y + h}`,     `Q${x}     ${y + h} ${x}     ${y + h - r}`,
-    `L${x}     ${y + r}`,     `Q${x}     ${y}     ${x + r} ${y}`,
+    `L${x + w - r} ${y}`,
+    `Q${x + w} ${y}     ${x + w} ${y + r}`,
+    `L${x + w} ${y + h - r}`,
+    `Q${x + w} ${y + h} ${x + w - r} ${y + h}`,
+    `L${x + r} ${y + h}`,
+    `Q${x}     ${y + h} ${x}     ${y + h - r}`,
+    `L${x}     ${y + r}`,
+    `Q${x}     ${y}     ${x + r} ${y}`,
     "Z",
   ].join(" ");
 }
 
-const HA_INPUT_YS  = [HA_H * 0.35, HA_H * 0.65];
+const HA_INPUT_YS = [HA_H * 0.35, HA_H * 0.65];
 const HA_OUTPUT_YS = [HA_H * 0.35, HA_H * 0.65];
 
 function getHalfAdderGeometry(activeColor: string): GateGeometry {
   return {
     bodyPath: rrPath(PAD, 4, HA_W - PAD * 2, HA_H - 8, RX),
-    outputX:   HA_W - PAD,
-    outputY:   HA_H / 2,
+    outputX: HA_W - PAD,
+    outputY: HA_H / 2,
     inputPinX: PAD,
-    inputYOverrides:  HA_INPUT_YS,
+    inputYOverrides: HA_INPUT_YS,
     outputYOverrides: HA_OUTPUT_YS,
     svgContent: (
       <>
-        <text x={HA_W / 2} y={HA_H * 0.14} textAnchor="middle"
-          fontSize="5.5" fontFamily="monospace" fontWeight="700"
-          letterSpacing="0.12em" fill={activeColor} opacity="0.3">1-BIT</text>
+        <text
+          x={HA_W / 2}
+          y={HA_H * 0.14}
+          textAnchor="middle"
+          fontSize="5.5"
+          fontFamily="monospace"
+          fontWeight="700"
+          letterSpacing="0.12em"
+          fill={activeColor}
+          opacity="0.3"
+        >
+          1-BIT
+        </text>
 
-        <text x={HA_W / 2} y={HA_H * 0.91} textAnchor="middle"
-          fontSize="5.5" fontFamily="monospace" fontWeight="700"
-          letterSpacing="0.12em" fill={activeColor} opacity="0.3">HA</text>
+        <text
+          x={HA_W / 2}
+          y={HA_H * 0.91}
+          textAnchor="middle"
+          fontSize="5.5"
+          fontFamily="monospace"
+          fontWeight="700"
+          letterSpacing="0.12em"
+          fill={activeColor}
+          opacity="0.3"
+        >
+          HA
+        </text>
 
-        <text x={PAD + 4} y={HA_INPUT_YS[0] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          fill={activeColor} opacity="0.55">A</text>
-        <text x={PAD + 4} y={HA_INPUT_YS[1] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          fill={activeColor} opacity="0.55">B</text>
+        <text
+          x={PAD + 4}
+          y={HA_INPUT_YS[0] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          A
+        </text>
+        <text
+          x={PAD + 4}
+          y={HA_INPUT_YS[1] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          B
+        </text>
 
-        <text x={HA_W - PAD - 4} y={HA_OUTPUT_YS[0] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          textAnchor="end" fill={activeColor} opacity="0.55">S</text>
-        <text x={HA_W - PAD - 4} y={HA_OUTPUT_YS[1] + 3.5}
-          fontSize="7" fontFamily="monospace" fontWeight="700"
-          textAnchor="end" fill={activeColor} opacity="0.55">C</text>
+        <text
+          x={HA_W - PAD - 4}
+          y={HA_OUTPUT_YS[0] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          textAnchor="end"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          S
+        </text>
+        <text
+          x={HA_W - PAD - 4}
+          y={HA_OUTPUT_YS[1] + 3.5}
+          fontSize="7"
+          fontFamily="monospace"
+          fontWeight="700"
+          textAnchor="end"
+          fill={activeColor}
+          opacity="0.55"
+        >
+          C
+        </text>
       </>
     ),
   };
@@ -62,8 +120,8 @@ export const HalfAdderNode = memo(({ id, data, isConnectable }: LogicGateProps) 
   const activeColor = data.preview
     ? "var(--color-foreground)"
     : data.state
-    ? "var(--color-success)"
-    : "var(--color-primary)";
+      ? "var(--color-success)"
+      : "var(--color-primary)";
 
   return (
     <GateRenderer

--- a/src/components/nodes/halfAdder.tsx
+++ b/src/components/nodes/halfAdder.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { memo } from "react";
+import { type GateGeometry, GateRenderer, H, type LogicGateProps, W } from "./base/index";
+
+const HA_W = W;
+const HA_H = H;
+const PAD  = 10;
+const RX   = 5;
+
+function rrPath(x: number, y: number, w: number, h: number, r: number) {
+  return [
+    `M${x + r} ${y}`,
+    `L${x + w - r} ${y}`,     `Q${x + w} ${y}     ${x + w} ${y + r}`,
+    `L${x + w} ${y + h - r}`, `Q${x + w} ${y + h} ${x + w - r} ${y + h}`,
+    `L${x + r} ${y + h}`,     `Q${x}     ${y + h} ${x}     ${y + h - r}`,
+    `L${x}     ${y + r}`,     `Q${x}     ${y}     ${x + r} ${y}`,
+    "Z",
+  ].join(" ");
+}
+
+const HA_INPUT_YS  = [HA_H * 0.35, HA_H * 0.65];
+const HA_OUTPUT_YS = [HA_H * 0.35, HA_H * 0.65];
+
+function getHalfAdderGeometry(activeColor: string): GateGeometry {
+  return {
+    bodyPath: rrPath(PAD, 4, HA_W - PAD * 2, HA_H - 8, RX),
+    outputX:   HA_W - PAD,
+    outputY:   HA_H / 2,
+    inputPinX: PAD,
+    inputYOverrides:  HA_INPUT_YS,
+    outputYOverrides: HA_OUTPUT_YS,
+    svgContent: (
+      <>
+        <text x={HA_W / 2} y={HA_H * 0.14} textAnchor="middle"
+          fontSize="5.5" fontFamily="monospace" fontWeight="700"
+          letterSpacing="0.12em" fill={activeColor} opacity="0.3">1-BIT</text>
+
+        <text x={HA_W / 2} y={HA_H * 0.91} textAnchor="middle"
+          fontSize="5.5" fontFamily="monospace" fontWeight="700"
+          letterSpacing="0.12em" fill={activeColor} opacity="0.3">HA</text>
+
+        <text x={PAD + 4} y={HA_INPUT_YS[0] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          fill={activeColor} opacity="0.55">A</text>
+        <text x={PAD + 4} y={HA_INPUT_YS[1] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          fill={activeColor} opacity="0.55">B</text>
+
+        <text x={HA_W - PAD - 4} y={HA_OUTPUT_YS[0] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          textAnchor="end" fill={activeColor} opacity="0.55">S</text>
+        <text x={HA_W - PAD - 4} y={HA_OUTPUT_YS[1] + 3.5}
+          fontSize="7" fontFamily="monospace" fontWeight="700"
+          textAnchor="end" fill={activeColor} opacity="0.55">C</text>
+      </>
+    ),
+  };
+}
+
+export const HalfAdderNode = memo(({ id, data, isConnectable }: LogicGateProps) => {
+  const activeColor = data.preview
+    ? "var(--color-foreground)"
+    : data.state
+    ? "var(--color-success)"
+    : "var(--color-primary)";
+
+  return (
+    <GateRenderer
+      id={id}
+      data={data}
+      isConnectable={isConnectable}
+      geometry={getHalfAdderGeometry(activeColor)}
+      label="HALF ADDER"
+      symbol="HA"
+      inputHandles={2}
+      outputHandles={2}
+      width={HA_W}
+      height={HA_H}
+    />
+  );
+});
+
+HalfAdderNode.displayName = "HalfAdderNode";

--- a/src/components/simulator/simulator-canvas.tsx
+++ b/src/components/simulator/simulator-canvas.tsx
@@ -10,14 +10,105 @@ import {
   useEdgesState,
   useNodesState,
 } from "@xyflow/react";
-import { LoaderCircle } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { LoaderCircle, RefreshCw, Table2, EyeOff, Eye } from "lucide-react";
 import { useFileSystem } from "@/hooks/use-file-system";
 import { useHasMounted } from "@/hooks/use-has-mounted";
 import { useSettingsStore } from "@/hooks/use-settings-store";
 import { useSimulatorLogic } from "@/hooks/use-simulator-logic";
 import { type GateNodeProps, nodeTypes } from "@/lib/types";
 import { Toolbar } from "./toolbar";
+import { TruthTable } from "./truth-table";
+
+function TruthTablePanel({ nodes, edges }: { nodes: any[]; edges: any[] }) {
+  const [key, setKey] = useState(0);
+  const [spinning, setSpinning] = useState(false);
+  const [visible, setVisible] = useState(true);
+
+  const handleRefresh = () => {
+    setSpinning(true);
+    setKey((k) => k + 1);
+    setTimeout(() => setSpinning(false), 600);
+  };
+
+  const isEmpty = nodes.length === 0;
+
+  return (
+    <>
+      <style>{`
+        @keyframes tt-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @keyframes tt-pulse { 0%,100% { opacity:1; } 50% { opacity:0.35; } }
+        @keyframes tt-slide-in { from { opacity:0; transform: translateY(-6px); } to { opacity:1; transform: translateY(0); } }
+        .tt-scroll::-webkit-scrollbar { width: 4px; height: 4px; }
+        .tt-scroll::-webkit-scrollbar-track { background: transparent; }
+        .tt-scroll::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 4px; }
+        .tt-scroll::-webkit-scrollbar-corner { background: transparent; }
+        .tt-spinning { animation: tt-spin 0.6s linear; }
+      `}</style>
+
+      {/* Toggle button */}
+      <div className={`flex justify-end ${visible ? "mb-2" : ""}`}>
+        <button
+          onClick={() => setVisible((v) => !v)}
+          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-accent transition-colors text-xs font-medium tracking-wide cursor-pointer"
+        >
+          {visible ? <EyeOff size={11} /> : <Eye size={11} />}
+          {visible ? "Hide table" : "Show table"}
+        </button>
+      </div>
+
+      {/* Panel */}
+      {visible && (
+        <div
+          className="bg-card border border-border rounded-xl overflow-hidden shadow-lg"
+          style={{
+            width: "clamp(360px, 26vw, 520px)",
+            animation: "tt-slide-in 0.18s ease",
+          }}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-3.5 py-2.5 border-b border-border bg-card">
+            <div className="flex items-center gap-2">
+              <span
+                className="block w-1.5 h-1.5 rounded-full bg-foreground"
+                style={{ animation: "tt-pulse 2.4s ease-in-out infinite" }}
+              />
+              <Table2 size={13} className="text-muted-foreground" />
+              <span className="text-xs font-semibold tracking-widest uppercase text-foreground">
+                Truth Table
+              </span>
+            </div>
+            <button
+              onClick={handleRefresh}
+              title="Refresh"
+              className="flex items-center justify-center w-7 h-7 rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+            >
+              <RefreshCw size={13} className={spinning ? "tt-spinning" : ""} />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div
+            className="tt-scroll overflow-auto"
+            style={{ maxHeight: "min(400px, 52vh)" }}
+          >
+            {isEmpty ? (
+              <div className="py-9 px-5 flex flex-col items-center gap-1.5 text-muted-foreground">
+                <span className="text-2xl opacity-30">⊞</span>
+                <span className="text-xs tracking-wide">Add nodes to the canvas</span>
+                <span className="text-xs opacity-60">to generate the truth table</span>
+              </div>
+            ) : (
+              <div style={{ minWidth: "max-content" }}>
+                <TruthTable key={key} nodes={nodes} edges={edges} />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
 
 export function SimulatorCanvas() {
   const hasMounted = useHasMounted();
@@ -31,14 +122,12 @@ export function SimulatorCanvas() {
     setEdges,
   );
 
-  // Auto-save current circuit when nodes or edges change
   useEffect(() => {
     if (currentFileId && (nodes.length > 0 || edges.length > 0)) {
       const saveTimeout = setTimeout(() => {
         console.debug("Saving file", currentFileId);
         updateFileContent(currentFileId, { nodes, edges });
-      }, 1000); // Auto-save after 1 second of inactivity
-
+      }, 1000);
       return () => clearTimeout(saveTimeout);
     }
   }, [nodes, edges, currentFileId, updateFileContent]);
@@ -47,7 +136,6 @@ export function SimulatorCanvas() {
     if (!ready) return;
     const currentFile = getCurrentFile();
     console.debug("Loading file", currentFileId);
-
     if (currentFile?.data) {
       setNodes(currentFile.data.nodes);
       setEdges(currentFile.data.edges);
@@ -82,9 +170,14 @@ export function SimulatorCanvas() {
         onNodeClick={(_, node) => onNodeClick(node)}
         fitView
       >
-        <Panel position="top-left">
+        <Panel position="top-left" className="flex flex-col gap-2 p-2">
           <Toolbar />
         </Panel>
+
+        <Panel position="top-right" className="m-3">
+          <TruthTablePanel nodes={nodes} edges={edges} />
+        </Panel>
+
         {settings.showMinimap && <MiniMap className="bg-card" />}
         {settings.showGrid && <Background gap={12} size={1} />}
       </ReactFlow>

--- a/src/components/simulator/simulator-canvas.tsx
+++ b/src/components/simulator/simulator-canvas.tsx
@@ -74,9 +74,7 @@ function TruthTablePanel({ nodes, edges }: { nodes: any[]; edges: any[] }) {
                 style={{ animation: "tt-pulse 2.4s ease-in-out infinite" }}
               />
               <Table2 size={13} className="text-muted-foreground" />
-              <span className="text-xs font-semibold tracking-widest uppercase text-foreground">
-                Truth Table
-              </span>
+              <span className="text-xs font-semibold tracking-widest uppercase text-foreground">Truth Table</span>
             </div>
             <button
               onClick={handleRefresh}
@@ -88,10 +86,7 @@ function TruthTablePanel({ nodes, edges }: { nodes: any[]; edges: any[] }) {
           </div>
 
           {/* Body */}
-          <div
-            className="tt-scroll overflow-auto"
-            style={{ maxHeight: "min(400px, 52vh)" }}
-          >
+          <div className="tt-scroll overflow-auto" style={{ maxHeight: "min(400px, 52vh)" }}>
             {isEmpty ? (
               <div className="py-9 px-5 flex flex-col items-center gap-1.5 text-muted-foreground">
                 <span className="text-2xl opacity-30">⊞</span>

--- a/src/components/simulator/toolbar.tsx
+++ b/src/components/simulator/toolbar.tsx
@@ -8,6 +8,10 @@ type GateProps = {
   label: string;
 };
 
+type ToolbarProps = {
+  children?: React.ReactNode;
+};
+
 function Gate({ nodeType, label }: GateProps) {
   const onDragStart = (event: React.DragEvent<HTMLDivElement>) => {
     event.dataTransfer.setData("application/@xyflow/react", nodeType);
@@ -79,7 +83,7 @@ const sections = [
   },
 ];
 
-export function Toolbar() {
+export function Toolbar({ children }: ToolbarProps) {
   return (
     <div className="w-80 bg-card rounded-2xl flex flex-col h-full border border-border/60 shadow-xl overflow-hidden">
       <div className="p-5 bg-linear-to-br from-primary/5 to-transparent">
@@ -102,6 +106,7 @@ export function Toolbar() {
           </section>
         ))}
       </div>
+        {children}
     </div>
   );
 }

--- a/src/components/simulator/toolbar.tsx
+++ b/src/components/simulator/toolbar.tsx
@@ -8,10 +8,6 @@ type GateProps = {
   label: string;
 };
 
-type ToolbarProps = {
-  children?: React.ReactNode;
-};
-
 function Gate({ nodeType, label }: GateProps) {
   const onDragStart = (event: React.DragEvent<HTMLDivElement>) => {
     event.dataTransfer.setData("application/@xyflow/react", nodeType);
@@ -81,9 +77,15 @@ const sections = [
       { nodeType: "dmuxGate", symbol: "DMUX", label: "DMUX" },
     ],
   },
+  {
+    title: "Adders",
+    gates: [
+      { nodeType: "halfAdder", symbol: "HA", label: "Half Adder" },
+      { nodeType: "fullAdder", symbol: "FA", label: "Full Adder" },
+    ],
+  },
 ];
-
-export function Toolbar({ children }: ToolbarProps) {
+export function Toolbar() {
   return (
     <div className="w-80 bg-card rounded-2xl flex flex-col h-full border border-border/60 shadow-xl overflow-hidden">
       <div className="p-5 bg-linear-to-br from-primary/5 to-transparent">
@@ -106,7 +108,6 @@ export function Toolbar({ children }: ToolbarProps) {
           </section>
         ))}
       </div>
-        {children}
     </div>
   );
 }

--- a/src/components/simulator/toolbar.tsx
+++ b/src/components/simulator/toolbar.tsx
@@ -2,11 +2,20 @@
 
 import { nodeTypes } from "@/lib/types";
 
-type GateProps = {
-  nodeType: string;
-  symbol: string;
-  label: string;
+const NODE_SIZES: Record<string, { w: number; h: number }> = {
+  default: { w: 100, h: 64 },
+  halfAdder: { w: 100, h: 64 },
+  fullAdder: { w: 100, h: 96 },
 };
+
+const PREVIEW_BOX = { w: 72, h: 52 };
+
+function getScale(nodeType: string): number {
+  const size = NODE_SIZES[nodeType] ?? NODE_SIZES.default;
+  return Math.min(PREVIEW_BOX.w / size.w, PREVIEW_BOX.h / size.h, 0.45);
+}
+
+type GateProps = { nodeType: string; symbol: string; label: string };
 
 function Gate({ nodeType, label }: GateProps) {
   const onDragStart = (event: React.DragEvent<HTMLDivElement>) => {
@@ -15,33 +24,41 @@ function Gate({ nodeType, label }: GateProps) {
   };
 
   const GateComponent = nodeTypes[nodeType];
+  const scale = getScale(nodeType);
 
   return (
     <div
-      className="group relative p-2.5 rounded-xl flex flex-col items-center justify-center cursor-grab active:cursor-grabbing transition-all duration-300 h-26 overflow-hidden bg-muted/30 border border-border hover:border-primary/50 hover:bg-muted/50"
+      className="group relative rounded-xl flex flex-col cursor-grab active:cursor-grabbing transition-all duration-300 overflow-hidden bg-muted/30 border border-border hover:border-primary/50 hover:bg-muted/50"
+      style={{ height: "6.5rem" }}
       draggable
       onDragStart={onDragStart}
     >
       <div className="absolute inset-0 bg-gradient-to-br from-primary/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-xl" />
-      <div className="flex-1 w-full flex items-center justify-center pointer-events-none scale-45 origin-center">
+
+      {/* preview area — absolutely centered in the upper portion */}
+      <div className="absolute inset-x-0 top-0 bottom-6 flex items-center justify-center pointer-events-none">
         {GateComponent && (
-          <GateComponent
-            id="preview"
-            data={{ label, state: false, preview: true }}
-            isConnectable={false}
-            selected={false}
-            type={nodeType}
-            zIndex={0}
-            positionAbsoluteX={0}
-            positionAbsoluteY={0}
-            dragging={false}
-            selectable={false}
-            deletable={false}
-            draggable={false}
-          />
+          <div style={{ transform: `scale(${scale})`, transformOrigin: "center center" }}>
+            <GateComponent
+              id="preview"
+              data={{ label, state: false, preview: true }}
+              isConnectable={false}
+              selected={false}
+              type={nodeType}
+              zIndex={0}
+              positionAbsoluteX={0}
+              positionAbsoluteY={0}
+              dragging={false}
+              selectable={false}
+              deletable={false}
+              draggable={false}
+            />
+          </div>
         )}
       </div>
-      <span className="text-xs font-medium mt-1 text-center text-muted-foreground group-hover:text-foreground transition-colors">
+
+      {/* label pinned to bottom */}
+      <span className="absolute bottom-0 inset-x-0 pb-2 text-xs font-medium text-center text-muted-foreground group-hover:text-foreground transition-colors">
         {label}
       </span>
     </div>
@@ -85,6 +102,7 @@ const sections = [
     ],
   },
 ];
+
 export function Toolbar() {
   return (
     <div className="w-80 bg-card rounded-2xl flex flex-col h-full border border-border/60 shadow-xl overflow-hidden">

--- a/src/lib/simulator.test.ts
+++ b/src/lib/simulator.test.ts
@@ -399,4 +399,141 @@ describe("calculateNodeStates", () => {
       expect(andNode?.data.state).toBe(true);
     });
   });
+  describe("Half Adder gate", () => {
+    it("outputs correct sum and carry when both inputs are false", () => {
+      const nodes: Node<GateNodeProps>[] = [
+        createToggleNode("A", false),
+        createToggleNode("B", false),
+        createGateNode("half", "halfAdder"),
+      ];
+      const edges: Edge[] = [
+        createEdge("A", "half", undefined, "input-0"),
+        createEdge("B", "half", undefined, "input-1"),
+      ];
+
+      const result = calculateNodeStates(nodes, edges);
+      const halfNode = result.find((n) => n.id === "half");
+
+      expect(halfNode?.data.outputs).toEqual([false, false]);
+      expect(halfNode?.data.state).toBe(false);
+    });
+
+    it("outputs sum true and carry false when A is true and B is false", () => {
+      const nodes: Node<GateNodeProps>[] = [
+        createToggleNode("A", true),
+        createToggleNode("B", false),
+        createGateNode("half", "halfAdder"),
+      ];
+      const edges: Edge[] = [
+        createEdge("A", "half", undefined, "input-0"),
+        createEdge("B", "half", undefined, "input-1"),
+      ];
+
+      const result = calculateNodeStates(nodes, edges);
+      const halfNode = result.find((n) => n.id === "half");
+
+      expect(halfNode?.data.outputs).toEqual([true, false]);
+      expect(halfNode?.data.state).toBe(true);
+    });
+
+    it("outputs sum false and carry true when both inputs are true", () => {
+      const nodes: Node<GateNodeProps>[] = [
+        createToggleNode("A", true),
+        createToggleNode("B", true),
+        createGateNode("half", "halfAdder"),
+      ];
+      const edges: Edge[] = [
+        createEdge("A", "half", undefined, "input-0"),
+        createEdge("B", "half", undefined, "input-1"),
+      ];
+
+      const result = calculateNodeStates(nodes, edges);
+      const halfNode = result.find((n) => n.id === "half");
+
+      expect(halfNode?.data.outputs).toEqual([false, true]);
+      expect(halfNode?.data.state).toBe(true);
+    });
+  });
+
+  describe("Full Adder gate", () => {
+    it("outputs correct sum and carry when all inputs are false", () => {
+      const nodes: Node<GateNodeProps>[] = [
+        createToggleNode("A", false),
+        createToggleNode("B", false),
+        createToggleNode("Cin", false),
+        createGateNode("full", "fullAdder"),
+      ];
+      const edges: Edge[] = [
+        createEdge("A", "full", undefined, "input-0"),
+        createEdge("B", "full", undefined, "input-1"),
+        createEdge("Cin", "full", undefined, "input-2"),
+      ];
+
+      const result = calculateNodeStates(nodes, edges);
+      const fullNode = result.find((n) => n.id === "full");
+
+      expect(fullNode?.data.outputs).toEqual([false, false]);
+      expect(fullNode?.data.state).toBe(false);
+    });
+
+    it("outputs sum true and carry false for one input true", () => {
+      const nodes: Node<GateNodeProps>[] = [
+        createToggleNode("A", true),
+        createToggleNode("B", false),
+        createToggleNode("Cin", false),
+        createGateNode("full", "fullAdder"),
+      ];
+      const edges: Edge[] = [
+        createEdge("A", "full", undefined, "input-0"),
+        createEdge("B", "full", undefined, "input-1"),
+        createEdge("Cin", "full", undefined, "input-2"),
+      ];
+
+      const result = calculateNodeStates(nodes, edges);
+      const fullNode = result.find((n) => n.id === "full");
+
+      expect(fullNode?.data.outputs).toEqual([true, false]);
+      expect(fullNode?.data.state).toBe(true);
+    });
+
+    it("outputs sum false and carry true for two inputs true", () => {
+      const nodes: Node<GateNodeProps>[] = [
+        createToggleNode("A", true),
+        createToggleNode("B", true),
+        createToggleNode("Cin", false),
+        createGateNode("full", "fullAdder"),
+      ];
+      const edges: Edge[] = [
+        createEdge("A", "full", undefined, "input-0"),
+        createEdge("B", "full", undefined, "input-1"),
+        createEdge("Cin", "full", undefined, "input-2"),
+      ];
+
+      const result = calculateNodeStates(nodes, edges);
+      const fullNode = result.find((n) => n.id === "full");
+
+      expect(fullNode?.data.outputs).toEqual([false, true]);
+      expect(fullNode?.data.state).toBe(true);
+    });
+
+    it("outputs sum true and carry true when all inputs are true", () => {
+      const nodes: Node<GateNodeProps>[] = [
+        createToggleNode("A", true),
+        createToggleNode("B", true),
+        createToggleNode("Cin", true),
+        createGateNode("full", "fullAdder"),
+      ];
+      const edges: Edge[] = [
+        createEdge("A", "full", undefined, "input-0"),
+        createEdge("B", "full", undefined, "input-1"),
+        createEdge("Cin", "full", undefined, "input-2"),
+      ];
+
+      const result = calculateNodeStates(nodes, edges);
+      const fullNode = result.find((n) => n.id === "full");
+
+      expect(fullNode?.data.outputs).toEqual([true, true]);
+      expect(fullNode?.data.state).toBe(true);
+    });
+  });
 });

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -147,49 +147,49 @@ export function calculateNodeStates(nodes: Node<GateNodeProps>[], edges: Edge[])
         if (sourceHandle === "output-1") return Y1;
         return Y0;
       }
-    case "halfAdder": {
-      const A = inputs[0] ?? false;
-      const B = inputs[1] ?? false;
+      case "halfAdder": {
+        const A = inputs[0] ?? false;
+        const B = inputs[1] ?? false;
 
-      const S = A !== B; // Soma (XOR)
-      const C = A && B;  // Carry
+        const S = A !== B; // Soma (XOR)
+        const C = A && B; // Carry
 
-      updatedNodes[nodeIndex] = {
-        ...updatedNodes[nodeIndex],
-        data: {
-          ...updatedNodes[nodeIndex].data,
-          outputs: [S, C],
-          state: S || C,
-          inputs: inputs,
-        },
-      };
+        updatedNodes[nodeIndex] = {
+          ...updatedNodes[nodeIndex],
+          data: {
+            ...updatedNodes[nodeIndex].data,
+            outputs: [S, C],
+            state: S || C,
+            inputs: inputs,
+          },
+        };
 
-      if (sourceHandle === "output-1") return C;
-      return S;
-    }
+        if (sourceHandle === "output-1") return C;
+        return S;
+      }
 
-    case "fullAdder": {
-      const A   = inputs[0] ?? false;
-      const B   = inputs[1] ?? false;
-      const Cin = inputs[2] ?? false;
+      case "fullAdder": {
+        const A = inputs[0] ?? false;
+        const B = inputs[1] ?? false;
+        const Cin = inputs[2] ?? false;
 
-      const sum3 = [A, B, Cin].filter(Boolean).length;
-      const S    = sum3 % 2 === 1;   // Sum
-      const Co   = sum3 >= 2;        // Carry out
+        const sum3 = [A, B, Cin].filter(Boolean).length;
+        const S = sum3 % 2 === 1; // Sum
+        const Co = sum3 >= 2; // Carry out
 
-      updatedNodes[nodeIndex] = {
-        ...updatedNodes[nodeIndex],
-        data: {
-          ...updatedNodes[nodeIndex].data,
-          outputs: [S, Co],
-          state: S || Co,
-          inputs: inputs,
-        },
-      };
+        updatedNodes[nodeIndex] = {
+          ...updatedNodes[nodeIndex],
+          data: {
+            ...updatedNodes[nodeIndex].data,
+            outputs: [S, Co],
+            state: S || Co,
+            inputs: inputs,
+          },
+        };
 
-      if (sourceHandle === "output-1") return Co;
-      return S;
-    }
+        if (sourceHandle === "output-1") return Co;
+        return S;
+      }
       case "outputNode":
         result = inputs[0] ?? false;
         break;

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -128,7 +128,6 @@ export function calculateNodeStates(nodes: Node<GateNodeProps>[], edges: Edge[])
         result = S ? B : A;
         break;
       }
-
       case "dmuxGate": {
         const dataIn = inputs[0];
         const sel = inputs[1];
@@ -148,7 +147,48 @@ export function calculateNodeStates(nodes: Node<GateNodeProps>[], edges: Edge[])
         if (sourceHandle === "output-1") return Y1;
         return Y0;
       }
+    case "halfAdder": {
+        const A = getByHandle("input-0");
+        const B = getByHandle("input-1");
+        const S  = A !== B;        
+        const C  = A && B;          
 
+        updatedNodes[nodeIndex] = {
+          ...updatedNodes[nodeIndex],
+          data: {
+            ...updatedNodes[nodeIndex].data,
+            outputs: [S, C],
+            state: S || C,
+          },
+        };
+
+        if (sourceHandle === "output-1") return C;
+        return S; 
+      }
+
+      // input-0 = A, input-1 = B, input-2 = Cin
+      // output-0 = Sum, output-1 = Cout
+      case "fullAdder": {
+        const A   = getByHandle("input-0");
+        const B   = getByHandle("input-1");
+        const Cin = getByHandle("input-2");
+
+        const sum3  = [A, B, Cin].filter(Boolean).length;
+        const S     = sum3 % 2 === 1;    
+        const Co    = sum3 >= 2;         
+
+        updatedNodes[nodeIndex] = {
+          ...updatedNodes[nodeIndex],
+          data: {
+            ...updatedNodes[nodeIndex].data,
+            outputs: [S, Co],
+            state: S || Co,
+          },
+        };
+
+        if (sourceHandle === "output-1") return Co;
+        return S;
+      }
       case "outputNode":
         result = inputs[0] ?? false;
         break;

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -148,47 +148,48 @@ export function calculateNodeStates(nodes: Node<GateNodeProps>[], edges: Edge[])
         return Y0;
       }
     case "halfAdder": {
-        const A = getByHandle("input-0");
-        const B = getByHandle("input-1");
-        const S  = A !== B;        
-        const C  = A && B;          
+      const A = inputs[0] ?? false;
+      const B = inputs[1] ?? false;
 
-        updatedNodes[nodeIndex] = {
-          ...updatedNodes[nodeIndex],
-          data: {
-            ...updatedNodes[nodeIndex].data,
-            outputs: [S, C],
-            state: S || C,
-          },
-        };
+      const S = A !== B; // Soma (XOR)
+      const C = A && B;  // Carry
 
-        if (sourceHandle === "output-1") return C;
-        return S; 
-      }
+      updatedNodes[nodeIndex] = {
+        ...updatedNodes[nodeIndex],
+        data: {
+          ...updatedNodes[nodeIndex].data,
+          outputs: [S, C],
+          state: S || C,
+          inputs: inputs,
+        },
+      };
 
-      // input-0 = A, input-1 = B, input-2 = Cin
-      // output-0 = Sum, output-1 = Cout
-      case "fullAdder": {
-        const A   = getByHandle("input-0");
-        const B   = getByHandle("input-1");
-        const Cin = getByHandle("input-2");
+      if (sourceHandle === "output-1") return C;
+      return S;
+    }
 
-        const sum3  = [A, B, Cin].filter(Boolean).length;
-        const S     = sum3 % 2 === 1;    
-        const Co    = sum3 >= 2;         
+    case "fullAdder": {
+      const A   = inputs[0] ?? false;
+      const B   = inputs[1] ?? false;
+      const Cin = inputs[2] ?? false;
 
-        updatedNodes[nodeIndex] = {
-          ...updatedNodes[nodeIndex],
-          data: {
-            ...updatedNodes[nodeIndex].data,
-            outputs: [S, Co],
-            state: S || Co,
-          },
-        };
+      const sum3 = [A, B, Cin].filter(Boolean).length;
+      const S    = sum3 % 2 === 1;   // Sum
+      const Co   = sum3 >= 2;        // Carry out
 
-        if (sourceHandle === "output-1") return Co;
-        return S;
-      }
+      updatedNodes[nodeIndex] = {
+        ...updatedNodes[nodeIndex],
+        data: {
+          ...updatedNodes[nodeIndex].data,
+          outputs: [S, Co],
+          state: S || Co,
+          inputs: inputs,
+        },
+      };
+
+      if (sourceHandle === "output-1") return Co;
+      return S;
+    }
       case "outputNode":
         result = inputs[0] ?? false;
         break;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,7 @@ import type { Edge, Node, NodeTypes } from "@xyflow/react";
 import { ANDGateNode } from "@/components/nodes/and";
 import { BUFFGateNode } from "@/components/nodes/buff";
 import { DMUXGateNode } from "@/components/nodes/dmux";
+import { HalfAdderNode } from "@/components/nodes/halfAdder";
 import { MUXGateNode } from "@/components/nodes/mux";
 import { NANDGateNode } from "@/components/nodes/nand";
 import { NORGateNode } from "@/components/nodes/nor";
@@ -29,6 +30,7 @@ export const nodeTypes: NodeTypes = {
   xnor3Gate: XNOR3GateNode,
   dmuxGate: DMUXGateNode,
   buffGate: BUFFGateNode,
+  halfAdder: HalfAdderNode,
 };
 
 export interface GateNodeProps {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,7 @@ import type { Edge, Node, NodeTypes } from "@xyflow/react";
 import { ANDGateNode } from "@/components/nodes/and";
 import { BUFFGateNode } from "@/components/nodes/buff";
 import { DMUXGateNode } from "@/components/nodes/dmux";
+import { FullAdderNode } from "@/components/nodes/fullAdder";
 import { HalfAdderNode } from "@/components/nodes/halfAdder";
 import { MUXGateNode } from "@/components/nodes/mux";
 import { NANDGateNode } from "@/components/nodes/nand";
@@ -31,6 +32,7 @@ export const nodeTypes: NodeTypes = {
   dmuxGate: DMUXGateNode,
   buffGate: BUFFGateNode,
   halfAdder: HalfAdderNode,
+  fullAdder: FullAdderNode,
 };
 
 export interface GateNodeProps {


### PR DESCRIPTION
This PR adds support for displaying the truth table in the editor and introduces the Half Adder and Full Adder components.

Changes include:
- Implementation of the Half Adder node with proper geometry and -handles.
- Implementation of the Full Adder node.
- Integration of truth table visualization in the editor.
- Adjust the toolbar to accept bigger gates

<img width="1890" height="832" alt="2026-03-06_18-19-29" src="https://github.com/user-attachments/assets/c49b7247-3089-4a56-b3f9-d14741ff4d76" />

